### PR TITLE
fix(BSPs): reverse driver compilation

### DIFF
--- a/FindSTM32F303BSP.cmake
+++ b/FindSTM32F303BSP.cmake
@@ -129,6 +129,14 @@ set(STM32F303BSP_VERSION "1.11.2" PARENT_SCOPE)
 set(STM32F303BSP_VERSION_STRING "1.11.2" PARENT_SCOPE)
 
 file(GLOB_RECURSE hal_driver_sources ${bsp_source}/Drivers/STM32F3xx_HAL_Driver/Src/*.c)
+# GLOB_RECURSE lists files in alphabetical order. That means that the hal, which is
+# structured so that each subsystem has stm32f3xx_hal_subsystem.c and
+# stm32g4xx_hal_subsystem_ex.c, will have subsystem.c packed into the archive
+# before hal_subsystem_ex.c. That breaks some of the hal code, which has weak definitions
+# of some functions in subsystem.c that should be overridden in subsystem_ex.c, but
+# if subsystem.c comes before subsystem_ex.c in the archive, the linker will pick
+# the weak one. By reversing the order, we make subsystem_ex come befeore subsystem,
+# and the correct function gets picked.
 list(REVERSE hal_driver_sources)
 add_library(
   STM32F303BSP_Drivers STATIC

--- a/FindSTM32F303BSP.cmake
+++ b/FindSTM32F303BSP.cmake
@@ -129,6 +129,7 @@ set(STM32F303BSP_VERSION "1.11.2" PARENT_SCOPE)
 set(STM32F303BSP_VERSION_STRING "1.11.2" PARENT_SCOPE)
 
 file(GLOB_RECURSE hal_driver_sources ${bsp_source}/Drivers/STM32F3xx_HAL_Driver/Src/*.c)
+list(REVERSE hal_driver_sources)
 add_library(
   STM32F303BSP_Drivers STATIC
   ${hal_driver_sources})

--- a/FindSTM32G4xx.cmake
+++ b/FindSTM32G4xx.cmake
@@ -103,6 +103,15 @@ set(STM32G4xx_BSP_VERSION "1.4.0" PARENT_SCOPE)
 set(STM32G4xx_BSP_VERSION_STRING "1.4.0" PARENT_SCOPE)
 
 file(GLOB_RECURSE hal_driver_sources ${bsp_source}/Drivers/STM32G4xx_HAL_Driver/Src/*.c)
+# GLOB_RECURSE lists files in alphabetical order. That means that the hal, which is
+# structured so that each subsystem has stm32g4xx_hal_subsystem.c and
+# stm32g4xx_hal_subsystem_ex.c, will have subsystem.c packed into the archive
+# before hal_subsystem_ex.c. That breaks some of the hal code, which has weak definitions
+# of some functions in subsystem.c that should be overridden in subsystem_ex.c, but
+# if subsystem.c comes before subsystem_ex.c in the archive, the linker will pick
+# the weak one. By reversing the order, we make subsystem_ex come befeore subsystem,
+# and the correct function gets picked.
+list(REVERSE hal_driver_sources)
 add_library(
         STM32G4xx_Drivers STATIC
         ${hal_driver_sources})


### PR DESCRIPTION
The STM32F3 hal uses a pattern of having functions defined as __weak in
stm32f3xx_hal_subsystem.c and then non-weak overrides in
stm32f3xx_hal_subsystem_ex.c. When you compile to a static library as we
do, the object files compiled from these source files are packed in the
order they were passed to the compiler, which is alphabetical because we
use GLOB_RECURSE to list all the files. That means subsystem.c comes
before subsystem_ex.c.

That in turn means that when you link the static library to our
executable, the linker finds the weak definition first, says, "OK that's
good enough", and stops looking.

This fix reverses the alphabetical order, which means the subsystem_ex
files come before the subsystem files, which means the correct symbol
gets  linked, which you can verify by linking with
-Wl,-trace-symbol=some-overridden-symbol or by using objdump -t to list
everything in the STM32F303BSP_Drivers.a library and noting that
subsystem_ex files come before subsystem files.

More details can be found here (as in, I probably-badly paraphrased the question and answer from here): https://stackoverflow.com/questions/51656838/attribute-weak-and-static-libraries