### PR TITLE
chore(cmake): add FindFlatBuffers.cmake

### DIFF
--- a/FindFlatbuffers.cmake
+++ b/FindFlatbuffers.cmake
@@ -1,0 +1,28 @@
+#[=======================================================================[.rst:
+FindFlatbuffers.cmake
+----------------
+
+This module is intended for use with ``find_package`` and should not be imported on
+its own.
+
+#]=======================================================================]
+
+Include(FetchContent)
+
+FetchContent_Declare(
+  flatbuffers
+  GIT_REPOSITORY "https://github.com/google/flatbuffers"
+  GIT_TAG        "v1.12.0"
+  PREFIX         ${CMAKE_SOURCE_DIR}/stm32-tools/flatbuffers
+)
+
+FetchContent_Populate(flatbuffers)
+
+FetchContent_GetProperties(flatbuffers
+    POPULATED Flatbuffers_POPULATED
+    SOURCE_DIR FlatBuffers_SOURCE_DIR
+    BINARY_DIR FlatBuffers_BINARY_DIR
+)
+
+set(FlatBuffers_FOUND TRUE)
+

--- a/FindFlatbuffers.cmake
+++ b/FindFlatbuffers.cmake
@@ -9,16 +9,17 @@ its own.
 
 Include(FetchContent)
 
+
 FetchContent_Declare(
-  flatbuffers
+  Flatbuffers
   GIT_REPOSITORY "https://github.com/google/flatbuffers.git"
   GIT_TAG        "v1.12.1"
   PREFIX         ${CMAKE_SOURCE_DIR}/stm32-tools/flatbuffers
 )
 
-FetchContent_Populate(flatbuffers)
+FetchContent_Populate(Flatbuffers)
 
-FetchContent_GetProperties(flatbuffers
+FetchContent_GetProperties(Flatbuffers
     POPULATED Flatbuffers_POPULATED
     SOURCE_DIR FlatBuffers_SOURCE_DIR
     BINARY_DIR FlatBuffers_BINARY_DIR

--- a/FindFlatbuffers.cmake
+++ b/FindFlatbuffers.cmake
@@ -11,8 +11,8 @@ Include(FetchContent)
 
 FetchContent_Declare(
   flatbuffers
-  GIT_REPOSITORY "https://github.com/google/flatbuffers"
-  GIT_TAG        "v1.12.0"
+  GIT_REPOSITORY "https://github.com/google/flatbuffers.git"
+  GIT_TAG        "v1.12.1"
   PREFIX         ${CMAKE_SOURCE_DIR}/stm32-tools/flatbuffers
 )
 


### PR DESCRIPTION
Add `FindFlatBuffers.cmake` to support google flat buffer in our ot3 modules.

My first attempt at something like this. It seems to work though. 