### PR TITLE
chore: add FindFreeRTOS.cmake

### DIFF
--- a/FindFreeRTOS.cmake
+++ b/FindFreeRTOS.cmake
@@ -1,0 +1,26 @@
+#[=======================================================================[.rst:
+
+FindFreeRTOS.cmake
+
+Download the FreeRTOS repo from github.
+
+#]=======================================================================]
+
+Include(FetchContent)
+
+FetchContent_Declare(
+        FreeRTOS
+        GIT_REPOSITORY https://github.com/FreeRTOS/FreeRTOS
+        GIT_TAG        V10.4.0
+        PREFIX         ${CMAKE_SOURCE_DIR}/stm32-tools/FreeRTOS
+)
+
+FetchContent_MakeAvailable(
+        FreeRTOS
+)
+
+FetchContent_GetProperties(
+        FreeRTOS
+        POPULATED FreeRTOS_POPULATED
+        SOURCE_DIR FreeRTOS_SOURCE_DIR
+)


### PR DESCRIPTION
For the purpose of using the FreeRTOS posix simulation we need portions of FreeRTOS which are not included in the build-cross build.

Specifically the `/Source/portable/ThirdParty/GCC/Posix` and a few other directories.

