### PR TITLE
chore: merge changes from ot3-firmware

### DIFF
--- a/FindOpenOCD.cmake
+++ b/FindOpenOCD.cmake
@@ -19,7 +19,7 @@ built into openocd live
 
 include(FetchContent)
 
-set(OPENOCD_VERSION "0.10.0-15")
+set(OPENOCD_VERSION "0.11.0-1")
 set(OPENOCD_DIR "${CMAKE_SOURCE_DIR}/stm32-tools/openocd")
 
 if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux")

--- a/FindSTM32G4xx.cmake
+++ b/FindSTM32G4xx.cmake
@@ -132,11 +132,9 @@ macro(add_STM32G4_driver prefix)
 endmacro()
 set(STM32G4xx_Drivers_FOUND ${bsp_populated} PARENT_SCOPE)
 
-if ("FreeRTOS" IN_LIST STM32G4xx_FIND_COMPONENTS)
-        set(freertos_source ${bsp_source}/Middlewares/Third_Party/FreeRTOS/Source)
-        set(freertos_port_source ${freertos_source}/portable/GCC/ARM_CM4F)
-        file(GLOB freertos_common_sources ${freertos_source}/*.c)
-endif()
+set(freertos_source ${bsp_source}/Middlewares/Third_Party/FreeRTOS/Source)
+set(freertos_port_source ${freertos_source}/portable/GCC/ARM_CM4F)
+file(GLOB freertos_common_sources ${freertos_source}/*.c)
 
 macro(add_STM32G4_freertos prefix)
         add_library(

--- a/FindSTM32G4xx.cmake
+++ b/FindSTM32G4xx.cmake
@@ -113,20 +113,20 @@ file(GLOB_RECURSE hal_driver_sources ${bsp_source}/Drivers/STM32G4xx_HAL_Driver/
 # and the correct function gets picked.
 list(REVERSE hal_driver_sources)
 
-macro(add_STM32G4_driver prefix)
+macro(add_STM32G4_driver suffix)
         add_library(
-                STM32G4xx_Drivers_${prefix} STATIC
+                STM32G4xx_Drivers_${suffix} STATIC
                 ${hal_driver_sources})
 
         target_include_directories(
-                STM32G4xx_Drivers_${prefix}
+                STM32G4xx_Drivers_${suffix}
                 PUBLIC ${bsp_source}/Drivers/STM32G4xx_HAL_Driver/Inc
                 ${bsp_source}/Drivers/STM32G4xx_HAL_Driver/Inc/Legacy
                 ${bsp_source}/Drivers/CMSIS/Device/ST/STM32G4xx/Include
                 ${bsp_source}/Drivers/CMSIS/Core/Include)
 
         set_target_properties(
-                STM32G4xx_Drivers_${prefix}
+                STM32G4xx_Drivers_${suffix}
                 PROPERTIES C_STANDARD 11
                 C_STANDARD_REQUIRED TRUE)
 endmacro()
@@ -136,20 +136,20 @@ set(freertos_source ${bsp_source}/Middlewares/Third_Party/FreeRTOS/Source)
 set(freertos_port_source ${freertos_source}/portable/GCC/ARM_CM4F)
 file(GLOB freertos_common_sources ${freertos_source}/*.c)
 
-macro(add_STM32G4_freertos prefix)
+macro(add_STM32G4_freertos suffix)
         add_library(
-                STM32G4xx_FreeRTOS_${prefix} STATIC
+                STM32G4xx_FreeRTOS_${suffix} STATIC
                 ${freertos_common_sources}
                 ${freertos_port_source}/port.c
                 $<IF:$<BOOL:$<TARGET_PROPERTY:FREERTOS_HEAP_IMPLEMENTATION>>,${freertos_source}/portable/MemMang/$<TARGET_PROPERTY:FREERTOS_HEAP_IMPLEMENTATION>.c,"">)
 
         target_include_directories(
-                STM32G4xx_FreeRTOS_${prefix}
+                STM32G4xx_FreeRTOS_${suffix}
                 PUBLIC ${freertos_source}/include
                 ${freertos_port_source})
 
         set_target_properties(
-                STM32G4xx_FreeRTOS_${prefix}
+                STM32G4xx_FreeRTOS_${suffix}
                 PROPERTIES C_STANDARD 11
                 C_STANDARD_REQUIRED TRUE)
 endmacro()

--- a/FindSTM32G4xx.cmake
+++ b/FindSTM32G4xx.cmake
@@ -112,44 +112,47 @@ file(GLOB_RECURSE hal_driver_sources ${bsp_source}/Drivers/STM32G4xx_HAL_Driver/
 # the weak one. By reversing the order, we make subsystem_ex come befeore subsystem,
 # and the correct function gets picked.
 list(REVERSE hal_driver_sources)
-add_library(
-        STM32G4xx_Drivers STATIC
-        ${hal_driver_sources})
 
-target_include_directories(
-        STM32G4xx_Drivers
-        PUBLIC ${bsp_source}/Drivers/STM32G4xx_HAL_Driver/Inc
-        ${bsp_source}/Drivers/STM32G4xx_HAL_Driver/Inc/Legacy
-        ${bsp_source}/Drivers/CMSIS/Device/ST/STM32G4xx/Include
-        ${bsp_source}/Drivers/CMSIS/Core/Include)
+macro(add_STM32G4_driver prefix)
+        add_library(
+                STM32G4xx_Drivers_${prefix} STATIC
+                ${hal_driver_sources})
 
-set_target_properties(
-        STM32G4xx_Drivers
-        PROPERTIES C_STANDARD 11
-        C_STANDARD_REQUIRED TRUE)
+        target_include_directories(
+                STM32G4xx_Drivers_${prefix}
+                PUBLIC ${bsp_source}/Drivers/STM32G4xx_HAL_Driver/Inc
+                ${bsp_source}/Drivers/STM32G4xx_HAL_Driver/Inc/Legacy
+                ${bsp_source}/Drivers/CMSIS/Device/ST/STM32G4xx/Include
+                ${bsp_source}/Drivers/CMSIS/Core/Include)
+
+        set_target_properties(
+                STM32G4xx_Drivers_${prefix}
+                PROPERTIES C_STANDARD 11
+                C_STANDARD_REQUIRED TRUE)
+endmacro()
 set(STM32G4xx_Drivers_FOUND ${bsp_populated} PARENT_SCOPE)
 
-
 if ("FreeRTOS" IN_LIST STM32G4xx_FIND_COMPONENTS)
-    set(freertos_source ${bsp_source}/Middlewares/Third_Party/FreeRTOS/Source)
-    set(freertos_port_source ${freertos_source}/portable/GCC/ARM_CM4F)
-    file(GLOB freertos_common_sources ${freertos_source}/*.c)
-
-    add_library(
-            STM32G4xx_FreeRTOS STATIC
-            ${freertos_common_sources}
-            ${freertos_port_source}/port.c
-            $<IF:$<BOOL:$<TARGET_PROPERTY:FREERTOS_HEAP_IMPLEMENTATION>>,${freertos_source}/portable/MemMang/$<TARGET_PROPERTY:FREERTOS_HEAP_IMPLEMENTATION>.c,"">)
-
-    target_include_directories(
-            STM32G4xx_FreeRTOS
-            PUBLIC ${freertos_source}/include
-            ${freertos_port_source})
-
-    set(STM32G4xx_FreeRTOS_FOUND ${bsp_populated} PARENT_SCOPE)
-    set_target_properties(
-            STM32G4xx_FreeRTOS
-            PROPERTIES C_STANDARD 11
-            C_STANDARD_REQUIRED TRUE)
-
+        set(freertos_source ${bsp_source}/Middlewares/Third_Party/FreeRTOS/Source)
+        set(freertos_port_source ${freertos_source}/portable/GCC/ARM_CM4F)
+        file(GLOB freertos_common_sources ${freertos_source}/*.c)
 endif()
+
+macro(add_STM32G4_freertos prefix)
+        add_library(
+                STM32G4xx_FreeRTOS_${prefix} STATIC
+                ${freertos_common_sources}
+                ${freertos_port_source}/port.c
+                $<IF:$<BOOL:$<TARGET_PROPERTY:FREERTOS_HEAP_IMPLEMENTATION>>,${freertos_source}/portable/MemMang/$<TARGET_PROPERTY:FREERTOS_HEAP_IMPLEMENTATION>.c,"">)
+
+        target_include_directories(
+                STM32G4xx_FreeRTOS_${prefix}
+                PUBLIC ${freertos_source}/include
+                ${freertos_port_source})
+
+        set_target_properties(
+                STM32G4xx_FreeRTOS_${prefix}
+                PROPERTIES C_STANDARD 11
+                C_STANDARD_REQUIRED TRUE)
+endmacro()
+set(STM32G4xx_FreeRTOS_FOUND ${bsp_populated} PARENT_SCOPE)


### PR DESCRIPTION
Pulls in changes to support using the STM32G4xx support in multiple places in the same project from ot3-firmware, as well as a bump to openocd to support STM32G4s.