### PR TITLE
feat: add include-what-you-use

### DIFF
--- a/0001-Apply-fix-for-bad-path-in-clang-12.patch
+++ b/0001-Apply-fix-for-bad-path-in-clang-12.patch
@@ -1,0 +1,37 @@
+From 99a42933ac1cd839a19781f09d1b12b4bce27778 Mon Sep 17 00:00:00 2001
+From: Seth Foster <seth@opentrons.com>
+Date: Thu, 22 Jul 2021 16:28:24 -0400
+Subject: [PATCH] Apply fix for bad path in clang 12
+
+---
+ CMakeLists.txt | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 923b4d9..e7ccfea 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,4 @@
+ cmake_minimum_required(VERSION 3.4.3)
+-
+ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+   message(STATUS "IWYU: out-of-tree configuration")
+   set(IWYU_IN_TREE OFF)
+@@ -17,6 +16,14 @@ if (NOT IWYU_IN_TREE)
+   project(include-what-you-use)
+ 
+   find_package(LLVM CONFIG REQUIRED)
++
++  if (APPLE)
++    if (LLVM_VERSION_MAJOR EQUAL 12)
++      set_target_properties(LLVMSupport PROPERTIES
++        INTERFACE_LINK_LIBRARIES "m;ZLIB::ZLIB;curses;LLVMDemangle")
++    endif()
++  endif()
++
+   find_package(Clang CONFIG REQUIRED)
+ 
+   list(APPEND CMAKE_MODULE_PATH ${LLVM_DIR})
+-- 
+2.30.1 (Apple Git-130)
+

--- a/FindClang.cmake
+++ b/FindClang.cmake
@@ -22,10 +22,12 @@ but other useful tools built on the clang frontend, such as clang-format and Cod
 
 Provides the variables
 - ``Clang_FOUND``: bool, true if found
-- ``Clang_EXECUTABLE``: the path to the clang frontend binary
+- ``Clang_EXECUTABLE``: the path to the clang (c) frontend binary
+- ``ClangXX_EXECUTABLE``: the path to the clang++ (c++) frontend binary
 - ``Clang_CLANGTIDY_EXECUTABLE``: the path to clang-tidy
 - ``Clang_CLANGFORMAT_EXECUTABLE``: the path to clang-format
 - ``Clang_CODECHECKER_EXECUTABLE``: the path to CodeChecker
+- ``Clang_DIRECTORY``: The path to the downloaded clang tree
 
 #]=======================================================================]
 
@@ -49,32 +51,39 @@ FetchContent_Declare(CLANG_LOCALINSTALL
   DOWNLOAD_DIR "${LOCALINSTALL_CLANG_DIR}/${CMAKE_HOST_SYSTEM_NAME}"
   URL "https://github.com/llvm/llvm-project/releases/download/llvmorg-${DL_CLANG_VERSION}/clang+llvm-${DL_CLANG_VERSION}-${CLANG_ARCHIVE}")
 
-FetchContent_GetProperties(CLANG_LOCALINSTALL
-  POPULATED CLANG_LOCALINSTALL_POPULATED)
-if(NOT CLANG_LOCALINSTALL_POPULATED)
+FetchContent_GetProperties(CLANG_LOCALINSTALL)
+if(NOT clang_localinstall_POPULATED)
   FetchContent_Populate(CLANG_LOCALINSTALL)
   message(STATUS "Downloaded new clang")
 endif()
 
 find_program(Clang_EXECUTABLE
   clang
-  PATHS ${CMAKE_SOURCE_DIR}/stm32-tools/clang/${CMAKE_HOST_SYSTEM_NAME}
-  PATH_SUFFIXES bin)
+  PATHS ${clang_localinstall_SOURCE_DIR}
+  PATH_SUFFIXES bin
+  NO_DEFAULT_PATH)
+
+find_program(ClangXX_EXECUTABLE
+  clang++
+  PATHS ${clang_localinstall_SOURCE_DIR}
+  PATH_SUFFIXES bin
+  NO_DEFAULT_PATH)
 
 find_program(Clang_CLANGFORMAT_EXECUTABLE
   clang-format
-  PATHS ${CMAKE_SOURCE_DIR}/stm32-tools/clang/${CMAKE_HOST_SYSTEM_NAME}
+  PATHS ${clang_localinstall_SOURCE_DIR}
   PATH_SUFFIXES bin
   NO_DEFAULT_PATH)
 
 find_program(Clang_CLANGTIDY_EXECUTABLE
   clang-tidy
-  PATHS ${CMAKE_SOURCE_DIR}/stm32-tools/clang/${CMAKE_HOST_SYSTEM_NAME}
-  PATH_SUFFIXES bin)
+  PATHS ${clang_localinstall_SOURCE_DIR}
+  PATH_SUFFIXES bin
+  NO_DEFAULT_PATH)
 
 find_program(Clang_CODECHECKER_EXECUTABLE
   CodeChecker
-  PATHS ${CMAKE_SOURCE_DIR}/stm32-tools/clang/${CMAKE_HOST_SYSTEM_NAME})
+  PATHS ${clang_localinstall_SOURCE_DIR})
 
 if (Clang_CODECHECKER_EXECUTABLE STREQUAL "Clang_CODECHECKER_EXECUTABLE_NOTFOUND")
   message(WARNING "Could not find codechecker, which is system-dependent. See https://codechecker.readthedocs.io/en/latest/#install-guide")
@@ -134,6 +143,8 @@ if (${INSTALLED_CLANG_VERSION} VERSION_LESS ${DL_CLANG_VERSION})
     message(STATUS "Found downloaded clang-format: ${Clang_CLANGFORMAT_EXECUTABLE}")
   endif()
 endif()
+
+set(Clang_DIRECTORY ${clang_localinstall_SOURCE_DIR})
 
 message(STATUS "Found clang-tidy at: ${Clang_CLANGTIDY_EXECUTABLE}")
 message(STATUS "Found clang-format at ${Clang_CLANGFORMAT_EXECUTABLE}")

--- a/FindIncludeWhatYouUse.cmake
+++ b/FindIncludeWhatYouUse.cmake
@@ -1,0 +1,103 @@
+#[=======================================================================[.rst:
+FindIncludeWhatYouUse.cmake
+---------------------------
+
+This module is intended for use with ``find_package`` and should not be imported on
+its own.
+
+It provides include-what-you-use (https://github.com/include-what-you-use/include-what-you-use/tree/clang_12),
+an add-on tool that ensures that all headers necessary to make a specific c++ file
+work are included and no headers that are not necessary are included.
+
+It will download (if necessary) the include-what-you-use source (there is no binary
+distribution provided) and compile it into the build directory. It will then create
+an appropriate invocation string in ``CMAKE_CXX_INCLUDE_WHAT_YOU_USE`` and
+``CMAKE_C_INCLUDE_WHAT_YOU_USE`` so that the tool will be run alongside compilation.
+
+The only necessary integration point should be calling
+``find_package(IncludeWhatYouUse)``.
+
+Provides the variables
+- ``IncludeWhatYouUse_FOUND``: bool, true if found
+- ``IncludeWhatYouUse_EXECUTABLE``: the path to the iwyu binary
+- ``CMAKE_CXX_INCLUDE_WHAT_YOU_USE``: internal variable with invocation command
+- ``CMAKE_C_INCLUDE_WHAT_YOU_USE``: internal variable with invocation command
+
+#]=======================================================================]
+
+find_package(Clang REQUIRED)
+find_package(Patch REQUIRED)
+
+set(LOCALINSTALL_IWYU_DIR "${CMAKE_SOURCE_DIR}/stm32-tools/iwyu")
+set(DL_IWYU_VERSION "0.16")
+
+message(STATUS "installing include-what-you-use ${DL_IWYU_VERSION} to ${LOCALINSTALL_IWYU_DIR}")
+
+FetchContent_Declare(IWYU_LOCALINSTALL
+  PREFIX "${LOCALINSTALL_IWYU_DIR}/${CMAKE_HOST_SYSTEM_NAME}"
+  # Patch does this: https://lists.llvm.org/pipermail/llvm-dev/2021-June/151554.html
+  PATCH_COMMAND ${Patch_EXECUTABLE} -i ${CMAKE_CURRENT_LIST_DIR}/0001-Apply-fix-for-bad-path-in-clang-12.patch
+  URL "https://include-what-you-use.org/downloads/include-what-you-use-${DL_IWYU_VERSION}.src.tar.gz")
+
+FetchContent_GetProperties(IWYU_LOCALINSTALL)
+
+if(NOT IWYU_LOCALINSTALL_POPULATED)
+  message(STATUS "Downloading iwyu")
+  FetchContent_Populate(IWYU_LOCALINSTALL)
+  FetchContent_GetProperties(IWYU_LOCALINSTALL)
+  message(STATUS "Downloaded iwyu")
+  message(STATUS "configuring iwyu for build ${iwyu_localinstall_BINARY_DIR} from ${iwyu_localinstall_SOURCE_DIR}")
+
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -DCMAKE_C_COMPILER=${Clang_EXECUTABLE} -DCMAKE_CXX_COMPILER=${ClangXX_EXECUTABLE} -DCMAKE_PREFIX_PATH=${Clang_DIRECTORY} -DCMAKE_VERBOSE_MAKEFILE=1 ${iwyu_localinstall_SOURCE_DIR}
+    COMMAND_ECHO STDOUT
+    WORKING_DIRECTORY ${iwyu_localinstall_BINARY_DIR}
+    COMMAND_ERROR_IS_FATAL ANY)
+  message(STATUS "building iwyu")
+  execute_process(
+    COMMAND make
+    COMMAND_ECHO STDOUT
+    WORKING_DIRECTORY ${iwyu_localinstall_BINARY_DIR}
+    COMMAND_ERROR_IS_FATAL ANY)
+  message(STATUS "built to ${iwyu_localinstall_BINARY_DIR}")
+endif()
+find_program(IncludeWhatYouUse_EXECUTABLE
+  include-what-you-use
+  PATHS ${iwyu_localinstall_BINARY_DIR}/bin
+  NO_DEFAULT_PATH
+  REQUIRED)
+set(IncludeWhatYouUse_FOUND TRUE)
+set(IncludeWhatYouUse_DIRECTORY ${iwyu_localinstall_BINARY_DIR})
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Gnu")
+  # If the compiler is gcc, then we need to make sure that iwyu (which uses
+  # clang to function) is using the appropriate standard library and system
+  # headers
+  find_library(
+    LIBSTDCPP
+    NAMES "libstdc++" "stdc++"
+    REQUIRED
+    HINTS /usr/local/lib)
+  find_path(
+    LIBSTDCPP_INC
+    NAMES array
+    HINTS /usr/local/include
+    REQUIRED
+    )
+  find_path(
+    LIBSTDCPP_BITS
+    NAMES "c++config.h"
+    HINTS /usr/local/include
+    REQUIRED
+    )
+
+  cmake_path(GET ${LIBSTDCPP_BITS} PARENT_PATH syspath)
+  set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE
+    "${IncludeWhatYouUse_EXECUTABLE}"
+    -stdlib=libstdc++
+    -stdlib++-isystem=${LIBSTDCPP_INC}
+    -cxx-isystem${syspath}
+    )
+else()
+  set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE "${IncludeWhatYouUse_EXECUTABLE}")
+endif()
+set(CMAKE_C_INCLUDE_WHAT_YOU_USE "${IncludeWhatYouUse_EXECUTABLE}")


### PR DESCRIPTION
Adds the include-what-you-use tool. This is another lint step that maeks
sure only appropriate headers are present, and that all required headers
are present (even if things are already compiling because those headers
are in some transitive #include). This makes things faster to compile
and also safer since you can't remove an include that doesn't seem like
it has anything to do with anything and suddenly break stuff.

Unfortunately, this also doesn't work because of [a clang bug](https://bugs.llvm.org/show_bug.cgi?id=50864) that prevents code that uses ranges from compiling in most cases. This breaks iwyu because iwyu depends on clang and llvm for semantic analysis.

Whenever upstream fixes that we can add iwyu.