### PR TITLE
refactor(cross toolchain): add separate tool chains for arm M4 and M33

### DIFF
--- a/STM32CortexM33GCCCrossToolchain.cmake
+++ b/STM32CortexM33GCCCrossToolchain.cmake
@@ -1,5 +1,5 @@
 #[=======================================================================[.rst:
-STM32GCCCrossToolchain.cmake
+STM32CortexM33GCCCrossToolchain.cmake
 ----------------------------
 
 This module should never be imported and used in a CMakeLists.txt file at either
@@ -21,9 +21,9 @@ set(CMAKE_ASM_COMPILER "${CrossGCC_BINDIR}/${CrossGCC_TRIPLE}-gcc")
 set(CMAKE_CXX_COMPILER "${CrossGCC_BINDIR}/${CrossGCC_TRIPLE}-g++")
 
 set(GCC_CROSS_BASE_FLAGS
-  "-mthumb -mcpu=cortex-m4 -mfloat-abi=hard -specs=nosys.specs -specs=nano.specs -fpic -ffunction-sections -fdata-sections -fno-lto")
-set(CMAKE_C_COMPILER_TARGET thumbv7m-unknown-none-eabi)
-set(CMAKE_CXX_COMPILER_TARGET thumbv7m-unknown-none-eabi)
+        "-mthumb -mcpu=cortex-m33 -mfloat-abi=hard -specs=nosys.specs -specs=nano.specs -fpic -ffunction-sections -fdata-sections -fno-lto")
+set(CMAKE_C_COMPILER_TARGET thumbv8m.main-none-eabi)
+set(CMAKE_CXX_COMPILER_TARGET thumbv8m.main-none-eabi)
 set(CMAKE_C_FLAGS ${GCC_CROSS_BASE_FLAGS})
 set(CMAKE_CXX_FLAGS ${GCC_CROSS_BASE_FLAGS})
 set(CMAKE_ASM_FLAGS ${GCC_CROSS_BASE_FLAGS})

--- a/STM32CortexM4GCCCrossToolchain.cmake
+++ b/STM32CortexM4GCCCrossToolchain.cmake
@@ -1,0 +1,32 @@
+#[=======================================================================[.rst:
+STM32CortexM4GCCCrossToolchain.cmake
+----------------------------
+
+This module should never be imported and used in a CMakeLists.txt file at either
+build or configuration time. It is only intended to be used as a toolchain specified
+either in a preset or with the ``-DCMAKE_TOOLCHAIN_FILE`` command-line option.
+
+It will download the appropriate gcc cross-compiler for arm to
+stm32-tools/gcc-arm-embedded and set some basic compile and linker flags (the
+CPU flags specified with ``-m``).
+#]=======================================================================]
+
+find_package(CrossGCC)
+
+set(CMAKE_SYSTEM_NAME "Generic")
+set(CMAKE_FIND_ROOT_PATH "${CMAKE_CURRENT_LIST_DIR}/../vendor")
+set(CMAKE_SYSROOT "${CrossGCC_DIR}/${CrossGCC_TRIPLE}")
+set(CMAKE_C_COMPILER "${CrossGCC_BINDIR}/${CrossGCC_TRIPLE}-gcc")
+set(CMAKE_ASM_COMPILER "${CrossGCC_BINDIR}/${CrossGCC_TRIPLE}-gcc")
+set(CMAKE_CXX_COMPILER "${CrossGCC_BINDIR}/${CrossGCC_TRIPLE}-g++")
+
+set(GCC_CROSS_BASE_FLAGS
+  "-mthumb -mcpu=cortex-m4 -mfloat-abi=hard -specs=nosys.specs -specs=nano.specs -fpic -ffunction-sections -fdata-sections -fno-lto")
+set(CMAKE_C_COMPILER_TARGET thumbv7m-unknown-none-eabi)
+set(CMAKE_CXX_COMPILER_TARGET thumbv7m-unknown-none-eabi)
+set(CMAKE_C_FLAGS ${GCC_CROSS_BASE_FLAGS})
+set(CMAKE_CXX_FLAGS ${GCC_CROSS_BASE_FLAGS})
+set(CMAKE_ASM_FLAGS ${GCC_CROSS_BASE_FLAGS})
+
+set(CMAKE_CROSSCOMPILING_EMULATOR "${CrossGCC_BINDIR}/${CrossGCC_TRIPLE}-gdb")
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)


### PR DESCRIPTION
## Overview

Waving the white flag trying to get target compile options to work in the way we need it to in order to build at the time the target executables are created.