### PR TITLE
feat:Add STM32G4 USB support

### DIFF
--- a/FindSTM32G4xx.cmake
+++ b/FindSTM32G4xx.cmake
@@ -155,7 +155,6 @@ macro(add_STM32G4_freertos suffix)
 endmacro()
 set(STM32G4xx_FreeRTOS_FOUND ${bsp_populated} PARENT_SCOPE)
 
-# TODO move this to the cmake_utils folder before putting in PR!
 macro(add_STM32G4_usb suffix)
         set(usb_root ${bsp_source}/Middlewares/ST/STM32_USB_Device_Library/)
         set(usb_core_root ${usb_root}/Core)

--- a/FindSTM32G4xx.cmake
+++ b/FindSTM32G4xx.cmake
@@ -154,3 +154,35 @@ macro(add_STM32G4_freertos suffix)
                 C_STANDARD_REQUIRED TRUE)
 endmacro()
 set(STM32G4xx_FreeRTOS_FOUND ${bsp_populated} PARENT_SCOPE)
+
+# TODO move this to the cmake_utils folder before putting in PR!
+macro(add_STM32G4_usb suffix)
+        set(usb_root ${bsp_source}/Middlewares/ST/STM32_USB_Device_Library/)
+        set(usb_core_root ${usb_root}/Core)
+        set(usb_cdc_root ${usb_root}/Class/CDC)
+        set(usb_class_sources
+                ${usb_cdc_root}/Src/usbd_cdc.c)
+        set(usb_core_sources
+                ${usb_core_root}/Src/usbd_core.c
+                ${usb_core_root}/Src/usbd_ctlreq.c
+                ${usb_core_root}/Src/usbd_ioreq.c)
+
+        add_library(
+                STM32G4xx_USB_${suffix} STATIC 
+                ${usb_core_sources}
+                ${usb_class_sources})
+
+        get_target_property(_hal_include_dirs STM32G4xx_Drivers_${suffix} INCLUDE_DIRECTORIES)
+
+        target_include_directories(
+                STM32G4xx_USB_${suffix}
+                PUBLIC  ${usb_core_root}/Inc
+                        ${usb_cdc_root}/Inc
+                        ${_hal_include_dirs})
+        
+        set_target_properties(
+                STM32G4xx_USB_${suffix}
+                PROPERTIES C_STANDARD 11
+                C_STANDARD_REQUIRED TRUE)
+endmacro()
+set(STM32G4xx_USB_FOUND ${bsp_populated} PARENT_SCOPE)


### PR DESCRIPTION
Adds support to link to the STM32G4 USB library (specifically the CDC library). Required for the Thermocycler-refresh board. Largely copied from `FindSTM32F303BSP.cmake` but thrown into a macro.