### PR TITLE
fix: ensure FindPoetry module uses pyenv python on mac

### DIFF
--- a/FindPoetry.cmake
+++ b/FindPoetry.cmake
@@ -27,6 +27,7 @@ string(REPLACE "." "_" "_poetry_archive_version_component" "${Poetry_FIND_VERSIO
 
 message(STATUS "Checking for installed Python package")
 set(Python_FIND_UNVERSIONED_NAMES "FIRST")  # Helps find pyenv if installed
+set(Python_FIND_FRAMEWORK "LAST") # Encourages cmake to find pyenv before macOS system version
 find_package(Python COMPONENTS Interpreter Development)
 if(NOT ${Python_FOUND})
 	message(FATAL_ERROR "Could not find installed python version. Cannot install poetry. Exiting...")


### PR DESCRIPTION
I had trouble with the `FindPoetry.cmake` module because it kept finding the macOS system install of Python over my local pyenv version, which resulted in the Poetry setup script failing to run. Adding this [hint](https://cmake.org/cmake/help/latest/module/FindPython.html#hints) encourages cmake to use the system version _last_ instead of preferring it.