### PR TITLE
fix(boost): update Boost archive URL

### DIFF
--- a/FindBoost.cmake
+++ b/FindBoost.cmake
@@ -55,7 +55,7 @@ Cache Variables
 include(FetchContent)
 string(REPLACE "." "_" "_boost_archive_version_component" "${Boost_FIND_VERSION}")
 set(boost_localinstall_root ${CMAKE_SOURCE_DIR}/stm32-tools/boost-${_boost_archive_version_component})
-set(boost_archive_root "https://boostorg.jfrog.io/artifactory/main/release")
+set(boost_archive_root "https://https://archives.boost.io/release")
 set(boost_archive_url "${boost_archive_root}/${Boost_FIND_VERSION}/source/boost_${_boost_archive_version_component}.zip")
 FetchContent_Declare(Boost
   PREFIX "${boost_localinstall_root}"

--- a/FindBoost.cmake
+++ b/FindBoost.cmake
@@ -55,7 +55,7 @@ Cache Variables
 include(FetchContent)
 string(REPLACE "." "_" "_boost_archive_version_component" "${Boost_FIND_VERSION}")
 set(boost_localinstall_root ${CMAKE_SOURCE_DIR}/stm32-tools/boost-${_boost_archive_version_component})
-set(boost_archive_root "https://https://archives.boost.io/release")
+set(boost_archive_root "https://archives.boost.io/release")
 set(boost_archive_url "${boost_archive_root}/${Boost_FIND_VERSION}/source/boost_${_boost_archive_version_component}.zip")
 FetchContent_Declare(Boost
   PREFIX "${boost_localinstall_root}"

--- a/boost-cmake/CMakeLists.txt
+++ b/boost-cmake/CMakeLists.txt
@@ -3,8 +3,8 @@ project(Boost-CMake)
 
 option(BOOST_DISABLE_TESTS "Do not build test targets, even if building standalone" OFF)
 
-set(BOOST_URL "https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2" CACHE STRING "Boost download URL")
-set(BOOST_URL_SHA256 "d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee" CACHE STRING "Boost download URL SHA256 checksum")
+set(BOOST_URL "https://archives.boost.io/release/1.81.0/source/boost_1_81_0.tar.bz2" CACHE STRING "Boost download URL")
+set(BOOST_URL_SHA256 "71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa" CACHE STRING "Boost download URL SHA256 checksum")
 
 include(FetchContent)
 FetchContent_Declare(


### PR DESCRIPTION
There as an error installing Boost because the release distributor JFrog is having issues. The current workaround is to use `archives.boost.io` download URL instead of the JFrog one. 