### PR TITLE
fix(boost): use stable URL for download

### DIFF
--- a/FindBoost.cmake
+++ b/FindBoost.cmake
@@ -55,7 +55,7 @@ Cache Variables
 include(FetchContent)
 string(REPLACE "." "_" "_boost_archive_version_component" "${Boost_FIND_VERSION}")
 set(boost_localinstall_root ${CMAKE_SOURCE_DIR}/stm32-tools/boost-${_boost_archive_version_component})
-set(boost_archive_root "https://boostorg.jfrog.io/artifactory/main/release")
+set(boost_archive_root "https://archives.boost.io/release")
 set(boost_archive_url "${boost_archive_root}/${Boost_FIND_VERSION}/source/boost_${_boost_archive_version_component}.zip")
 FetchContent_Declare(Boost
   PREFIX "${boost_localinstall_root}"

--- a/boost-cmake/CMakeLists.txt
+++ b/boost-cmake/CMakeLists.txt
@@ -3,7 +3,7 @@ project(Boost-CMake)
 
 option(BOOST_DISABLE_TESTS "Do not build test targets, even if building standalone" OFF)
 
-set(BOOST_URL "https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.bz2" CACHE STRING "Boost download URL")
+set(BOOST_URL "https://archives.boost.io/release/1.71.0/source/boost_1_71_0.tar.bz2" CACHE STRING "Boost download URL")
 set(BOOST_URL_SHA256 "d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee" CACHE STRING "Boost download URL SHA256 checksum")
 
 include(FetchContent)


### PR DESCRIPTION
Downloading boost from JFrog has been failing. I followed the workaround in [here](https://github.com/facebook/react-native/issues/42180) to update the download url for Boost to using the more stable `archives.boost.io`, and it worked for me locally. 